### PR TITLE
Feat/improve mathpix loader

### DIFF
--- a/src/loader.py
+++ b/src/loader.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import io
 import json
+import pathlib
+import zipfile
 from typing import Any
 
+import requests
 from langchain.docstore.document import Document
 from langchain.document_loaders import MathpixPDFLoader
 
@@ -18,7 +22,8 @@ class CustomMathpixLoader(MathpixPDFLoader):
     def __init__(
         self,
         file_path: str,
-        processed_file_format: str = "mmd",
+        output_path_for_tex: pathlib.Path,
+        processed_file_format: list[str] = ["mmd", "tex.zip"],
         max_wait_time_seconds: int = 500,
         should_clean_pdf: bool = False,
         output_langchain_document: bool = True,
@@ -27,6 +32,7 @@ class CustomMathpixLoader(MathpixPDFLoader):
     ) -> None:
         self.output_langchain_document = output_langchain_document
         self.other_request_parameters = other_request_parameters
+        self.output_path_for_tex = output_path_for_tex
         super().__init__(
             file_path,
             processed_file_format,
@@ -37,8 +43,9 @@ class CustomMathpixLoader(MathpixPDFLoader):
 
     @property
     def data(self) -> dict:
+        conversion_formats = {f: True for f in self.processed_file_format}
         options = {
-            "conversion_formats": {self.processed_file_format: True},
+            "conversion_formats": conversion_formats,
             **self.other_request_parameters,
         }
         return {"options_json": json.dumps(options)}
@@ -54,3 +61,17 @@ class CustomMathpixLoader(MathpixPDFLoader):
         else:
             output = contents
         return output
+
+    def get_processed_pdf(self, pdf_id: str) -> dict[str, str]:
+        self.wait_for_processing(pdf_id)
+        responses = dict()
+        for conversion_formats in self.processed_file_format:
+            url = f"{self.url}/{pdf_id}.{conversion_formats}"
+            response = requests.get(url, headers=self.headers)
+            if conversion_formats == "tex.zip":
+                with zipfile.ZipFile(io.BytesIO(response.content)) as z:
+                    z.extractall(self.output_path_for_tex)
+                    responses["tex.zip"] = self.output_path_for_tex
+            else:
+                responses[conversion_formats] = response.content.decode("utf-8")
+        return responses

--- a/src/scripts/convert_to_latex.py
+++ b/src/scripts/convert_to_latex.py
@@ -54,12 +54,14 @@ for i, paper in enumerate(papers):
     logger.info(f"[{i+1}/{len(papers)}] `{paper.title}` is sent to Mathpix API.")
     latex_text = CustomMathpixLoader(
         file_path=str(pdf_file_path),
+        output_path_for_tex=directory_path,
+        processed_file_format=["mmd", "tex.zip"],
         other_request_parameters={
             "math_inline_delimiters": ["$", "$"],
             "math_display_delimiters": ["$$", "$$"],
         },
         output_langchain_document=False,
-    ).load()
+    ).load()["mmd"]
 
     # Save latex format text.
     with mathpix_file_path.open("w") as f:

--- a/src/scripts/download_papers.py
+++ b/src/scripts/download_papers.py
@@ -20,7 +20,7 @@ paper_info_path: Final = pathlib.Path("./data/papers.json")
 # Check JSON file existence.
 if not paper_info_path.exists():
     error_message: Final = f"This scripts requires `{str(paper_info_path)}`. \
-        Please run `parse_cvf_page.py` frist to generate JSON file."
+        Please run `parse_cvf_page.py` first to generate JSON file."
     raise FileNotFoundError(error_message)
 
 # Load JSON and validate by Pydantic model.


### PR DESCRIPTION
## Issue URL

NA

## Change overview

- Change to get not only `mmd` format file but tex file when using mathpix API
- Fixed typo

## How to test

 - Run `convert_to_latex.py` and check the unzipped tex file is downloaded under each paper directory

## Note for reviewers

If this change does not seem helpful and should not be merged into the base branch, please close this.
